### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,12 +48,14 @@
             <a
               href="https://www.linkedin.com/in/ananyaa-mylsamy/"
               target="_blank"
+              rel="noopener noreferrer"
               aria-label="LinkedIn"
               ><i class="fab fa-linkedin"></i
             ></a>
             <a
               href="https://github.com/Anumyl"
               target="_blank"
+              rel="noopener noreferrer"
               aria-label="GitHub"
               ><i class="fab fa-github"></i
             ></a>
@@ -62,7 +64,6 @@
 
         <div class="intro-content">
           <h1>Code, Teach, Research & Create!</h1>
-          <br />
           <div class="action-buttons">
             <a href="work.html" class="btn-primary">PORTFOLIO</a>
             <a href="palette.html" class="btn-primary">MY PALETTE!</a>
@@ -76,7 +77,7 @@
             When I step away from code, you'll find me with a paintbrush!
           </p>
 
-          <p class="description" style="margin-top: 1rem; font-weight: 500">
+          <p class="description tagline">
             Always eager to connect with passionate innovators!
           </p>
         </div>


### PR DESCRIPTION
Removed the <br /> tag (from line 65, which was used for spacing) as it violates separation of concerns. The intended spacing can be achieved by updating ".intro-content h1 {margin-bottom: 2rem;}" in homepage.css. HTML should only define structure while CSS is responsible for presentation. 

Removed the style attribute (from line 80, for description) for the same reason as above, and added semantic class "tagline". The styling ('margin-top: 1rem; font-weight: 500') can be defined in homepage.css under '.tagline' selector for better maintainability and reusability.

Added rel="noopener noreferrer" for links (lines 50-60, LinkedIn & Github) with target="_blank" to improve security and privacy. Prevents reverse tabnabbing and avoids sending referrer data. It’s generally considered best practice to include this whenever links open in a new tab.