### PR TITLE
Update work.html

### DIFF
--- a/work.html
+++ b/work.html
@@ -65,6 +65,7 @@
               href="https://link.springer.com/chapter/10.1007/978-981-19-0019-8_44"
               class="publication-link"
               target="_blank"
+              rel="noopener noreferrer"
               >View Publication</a
             >
           </div>
@@ -99,6 +100,7 @@
               href="https://www.liebertpub.com/doi/abs/10.1089/big.2021.0012"
               class="publication-link"
               target="_blank"
+              rel="noopener noreferrer"
               >View Publication</a
             >
           </div>
@@ -119,6 +121,7 @@
               href="https://github.com/Anumyl/HYPOTENSION"
               class="project-link"
               target="_blank"
+              rel="noopener noreferrer"
               >View on GitHub</a
             >
           </div>
@@ -136,6 +139,7 @@
               href="https://github.com/Anumyl/LANDSCAPE"
               class="project-link"
               target="_blank"
+              rel="noopener noreferrer"
               >View on GitHub</a
             >
           </div>
@@ -151,6 +155,7 @@
               href="https://github.com/Anumyl/PHARM_SQL"
               class="project-link"
               target="_blank"
+              rel="noopener noreferrer"
               >View on GitHub</a
             >
           </div>
@@ -168,6 +173,7 @@
               href="https://link.springer.com/chapter/10.1007/978-981-19-0019-8_44"
               class="project-link"
               target="_blank"
+              rel="noopener noreferrer"
               >View on GitHub</a
             >
           </div>
@@ -185,12 +191,14 @@
               <a
                 href="https://www.linkedin.com/in/ananyaa-mylsamy/"
                 target="_blank"
+                rel="noopener noreferrer"
                 aria-label="LinkedIn"
                 ><i class="fab fa-linkedin"></i
               ></a>
               <a
                 href="https://github.com/Anumyl"
                 target="_blank"
+                rel="noopener noreferrer"
                 aria-label="GitHub"
                 ><i class="fab fa-github"></i
               ></a>


### PR DESCRIPTION
Added rel="noopener noreferrer" for links with target="_blank" to improve security and privacy. Prevents reverse tabnabbing and avoids sending referrer data. It’s generally considered best practice to include this whenever links open in a new tab.